### PR TITLE
removed rur from listed of required cookie value in cookie auth, becu…

### DIFF
--- a/src/Scrapper.php
+++ b/src/Scrapper.php
@@ -64,7 +64,7 @@ abstract class Scrapper
     protected static array $requiredCookies = [
         'csrftoken',
         'sessionid',
-        'rur',
+        //'rur', maynot be required
         'mid',
         'ig_did',
         'ds_user_id',


### PR DESCRIPTION
…ase it will not always be present and may not be necessarily required